### PR TITLE
Setup travis and update the package doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,9 @@ cache:
     - node_modules
 before_script:
   - cd ./example
-  - yarn install
+  - npm install
 script:
-  - yarn test
-  - yarn run build
+  - npm run build
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+node_js:
+  - "stable"
+cache:
+  directories:
+    - node_modules
+before_script:
+  - cd ./example
+  - yarn install
+script:
+  - yarn test
+  - yarn run build
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $github_token
+  local_dir: example/build
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Dead simple global store using hooks for react.
 
-## [Demo](https://lazhari.github.io/global-hook-store)
+## [Demo](https://richarddd.github.io/global-hook-store)
 
 ## TL&#59;DR
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Dead simple global store using hooks for react.
 
+## [Demo](https://lazhari.github.io/global-hook-store)
+
 ## TL&#59;DR
 
 Counter: https://codesandbox.io/s/j2v0p6kq7w

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "keywords": [],
   "main": "src/index.tsx",
-  "homepage": "https://lazhari.github.io/global-hook-store/",
+  "homepage": "https://richarddd.github.io/global-hook-store/",
   "dependencies": {
     "@material-ui/core": "^4.0.0-alpha.1",
     "@material-ui/styles": "^4.0.0-alpha.1",

--- a/example/package.json
+++ b/example/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "keywords": [],
   "main": "src/index.tsx",
+  "homepage": "https://lazhari.github.io/global-hook-store/",
   "dependencies": {
     "@material-ui/core": "^4.0.0-alpha.1",
     "@material-ui/styles": "^4.0.0-alpha.1",


### PR DESCRIPTION
To deploy the example app, we need to set up Travis with Github pages by setting the `github_token`

1. Go to GitHub.com -> Settings -> Applications -> Personal Access Tokens  -> Create new token, and copy it to your clipboard
2. Setting up Travis CI to build and deploy the site by going to the global-hook-store and set the environment variables `github_token`

:tada:

